### PR TITLE
Parse hairstyle race/gender restrictions properly

### DIFF
--- a/CollectorsAnxiety/Game/GameCompat.cs
+++ b/CollectorsAnxiety/Game/GameCompat.cs
@@ -11,4 +11,9 @@ public class GameCompat {
         Hrothgar = 7,
         Viera = 8
     }
+
+    public enum PlayerGender : sbyte {
+        Male = 0,
+        Female = 1
+    }
 }

--- a/CollectorsAnxiety/Resources/Localization/UIStrings.Designer.cs
+++ b/CollectorsAnxiety/Resources/Localization/UIStrings.Designer.cs
@@ -285,11 +285,47 @@ namespace CollectorsAnxiety.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Available to female Hrothgar characters.
+        /// </summary>
+        internal static string HairstyleTab_Icon_AvailableToFemaleHrothgar {
+            get {
+                return ResourceManager.GetString("HairstyleTab_Icon_AvailableToFemaleHrothgar", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Available to female Viera characters.
+        /// </summary>
+        internal static string HairstyleTab_Icon_AvailableToFemaleViera {
+            get {
+                return ResourceManager.GetString("HairstyleTab_Icon_AvailableToFemaleViera", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Available to Hrothgar characters.
         /// </summary>
         internal static string HairstyleTab_Icon_AvailableToHrothgar {
             get {
                 return ResourceManager.GetString("HairstyleTab_Icon_AvailableToHrothgar", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Available to male Hrothgar characters.
+        /// </summary>
+        internal static string HairstyleTab_Icon_AvailableToMaleHrothgar {
+            get {
+                return ResourceManager.GetString("HairstyleTab_Icon_AvailableToMaleHrothgar", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Available to male Viera characters.
+        /// </summary>
+        internal static string HairstyleTab_Icon_AvailableToMaleViera {
+            get {
+                return ResourceManager.GetString("HairstyleTab_Icon_AvailableToMaleViera", resourceCulture);
             }
         }
         

--- a/CollectorsAnxiety/Resources/Localization/UIStrings.resx
+++ b/CollectorsAnxiety/Resources/Localization/UIStrings.resx
@@ -164,8 +164,20 @@
     <data name="HairstyleTab_Icon_AvailableToHrothgar" xml:space="preserve">
         <value>Available to Hrothgar characters</value>
     </data>
+    <data name="HairstyleTab_Icon_AvailableToMaleHrothgar" xml:space="preserve">
+        <value>Available to male Hrothgar characters</value>
+    </data>
+    <data name="HairstyleTab_Icon_AvailableToFemaleHrothgar" xml:space="preserve">
+        <value>Available to female Hrothgar characters</value>
+    </data>
     <data name="HairstyleTab_Icon_AvailableToViera" xml:space="preserve">
         <value>Available to Viera characters</value>
+    </data>
+    <data name="HairstyleTab_Icon_AvailableToMaleViera" xml:space="preserve">
+        <value>Available to male Viera characters</value>
+    </data>
+    <data name="HairstyleTab_Icon_AvailableToFemaleViera" xml:space="preserve">
+        <value>Available to female Viera characters</value>
     </data>
     <data name="FramersKitTab_Name" xml:space="preserve">
         <value>Framer's Kits</value>

--- a/CollectorsAnxiety/UI/DataTabs/HairstyleTab.cs
+++ b/CollectorsAnxiety/UI/DataTabs/HairstyleTab.cs
@@ -26,17 +26,38 @@ public class HairstyleTab : DataTab<HairstyleEntry, CharaMakeCustomize> {
         if (entry.WearableByFemale && !entry.WearableByMale)
             ImGuiUtil.HoverMarker(FontAwesomeIcon.Venus, UIStrings.HairstyleTab_Icon_LimitedToFemale);
 
-        if (entry.WearableByRaceIDs.Contains(GameCompat.PlayerRace.Hrothgar))
-            ImGuiUtil.HoverMarker(FontAwesomeIcon.Paw, UIStrings.HairstyleTab_Icon_AvailableToHrothgar);
+        var maleHrothgar = entry.WearableByMaleRaceIDs.Contains(GameCompat.PlayerRace.Hrothgar);
+        var femaleHrothgar = entry.WearableByFemaleRaceIDs.Contains(GameCompat.PlayerRace.Hrothgar);
+        var maleViera = entry.WearableByMaleRaceIDs.Contains(GameCompat.PlayerRace.Viera);
+        var femaleViera = entry.WearableByFemaleRaceIDs.Contains(GameCompat.PlayerRace.Viera);
 
-        if (entry.WearableByRaceIDs.Contains(GameCompat.PlayerRace.Viera))
+        if (maleHrothgar && femaleHrothgar) {
+            ImGuiUtil.HoverMarker(FontAwesomeIcon.Paw, UIStrings.HairstyleTab_Icon_AvailableToHrothgar);
+        } else if (maleHrothgar && !femaleHrothgar) {
+            ImGuiUtil.HoverMarker(FontAwesomeIcon.Paw, UIStrings.HairstyleTab_Icon_AvailableToMaleHrothgar);
+        } else if (!maleHrothgar && femaleHrothgar) {
+            ImGuiUtil.HoverMarker(FontAwesomeIcon.Paw, UIStrings.HairstyleTab_Icon_AvailableToFemaleHrothgar);
+        }
+
+        if (maleViera && femaleViera) {
             ImGuiUtil.HoverMarker(FontAwesomeIcon.Carrot, UIStrings.HairstyleTab_Icon_AvailableToViera);
+        } else if (maleViera && !femaleViera) {
+            ImGuiUtil.HoverMarker(FontAwesomeIcon.Carrot, UIStrings.HairstyleTab_Icon_AvailableToMaleViera);
+        } else if (!maleViera && femaleViera) {
+            ImGuiUtil.HoverMarker(FontAwesomeIcon.Carrot, UIStrings.HairstyleTab_Icon_AvailableToFemaleViera);
+        }
     }
 
     protected override void DrawDevContextMenuItems(HairstyleEntry entry) {
-        var atrList = entry.WearableByRaceIDs.ToList();
-        ImGui.MenuItem($"Available To Races:", false);
-        foreach (var chunk in atrList.ChunksOf(3)) {
+        var matrList = entry.WearableByMaleRaceIDs.ToList();
+        ImGui.MenuItem("Available To Races (Male):", false);
+        foreach (var chunk in matrList.ChunksOf(3)) {
+            ImGui.MenuItem("   " + string.Join(", ", chunk), false);
+        }
+
+        var fatrList = entry.WearableByFemaleRaceIDs.ToList();
+        ImGui.MenuItem("Available To Races (Female):", false);
+        foreach (var chunk in fatrList.ChunksOf(3)) {
             ImGui.MenuItem("   " + string.Join(", ", chunk), false);
         }
     }


### PR DESCRIPTION
We were basing them off ID numbers before, but it looks like all this data is in the HairMakeType spreadsheet.

Hopefully at some point I will have time to reverse engineer this a bit more and do something better than "every 9 columns seems right, and about 100 of them also seems right". There's room for about 14 more hairstyles on male hyur though so hopefully this won't break too soon.

Fixes #23.