### PR TITLE
Disable fail-fast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         dalamud_url:
           - https://goatcorp.github.io/dalamud-distrib/stg/latest.zip


### PR DESCRIPTION
We always want to build against all Dalamud versions, even if one fails, since sometimes it's ignorable that one fails (e.g. when there's a new api version around a patch).